### PR TITLE
Add targetted action tracking

### DIFF
--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.9.4
+// @version      1.9.5
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.9.5
+// @version      1.9.4
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -10,9 +10,8 @@
 // @grant        GM_getValue
 // @grant        GM_setValue
 // @run-at       document-idle
-// @inject-into  page
 // ==/UserScript==
-
+window.eval(`
 /** @namespace */
 const Koviko = {
   /**
@@ -34,7 +33,7 @@ const Koviko = {
    * @prop {string} name Name of the action
    * @prop {number} expMult Experience multiplier (typically 1)
    * @prop {number} townNum The town to which the action belongs
-   * @prop {string} varName The unique identifier used for variables in the `towns` array
+   * @prop {string} varName The unique identifier used for variables in the \`towns\` array
    * @prop {number} [segments] Amount of segments per loop
    * @prop {number} [dungeonNum] The dungeon to which the action belongs
    * @prop {Object.<string, number>} stats Stats that affect and are affected by the action
@@ -308,7 +307,7 @@ const Koviko = {
      * Progression
      * @typedef {Object} Koviko.Predictor~Progression
      * @prop {number} completed The amount of total segments completed
-     * @prop {number} progress The amount of progress in segments beyond that already represented in `completed`
+     * @prop {number} progress The amount of progress in segments beyond that already represented in \`completed\`
      * @prop {number} total The amount of successful loops ever completed
      */
 
@@ -356,21 +355,21 @@ const Koviko = {
       if(typeof localStorage !== "undefined") { 
         if (localStorage.getItem('timePrecision') !== undefined) {
           var loadedVal = localStorage.getItem('timePrecision');
-          $('#updateTimePrecision').val(loadedVal);
+          \$('#updateTimePrecision').val(loadedVal);
         }
         if (localStorage.getItem("actionWidth")!=="undefined") {
           let tmpVal=localStorage.getItem("actionWidth");
           document.getElementById("actionsColumn").style.width=tmpVal+"px";
           document.getElementById("nextActionsListContainer").style.width=(tmpVal-120)+"px";
-          $('#actionWidth').val(tmpVal);
+          \$('#actionWidth').val(tmpVal);
         }
       }
-      // Prepare `updateNextActions` to be hooked
+      // Prepare \`updateNextActions\` to be hooked
       if (!view._updateNextActions) {
         view._updateNextActions = view.updateNextActions;
       }
 
-      // Hook `updateNextActions` with the predictor's update function
+      // Hook \`updateNextActions\` with the predictor's update function
       view.updateNextActions = () => {
         view._updateNextActions();
         this.update(actions.next, container);
@@ -402,7 +401,7 @@ const Koviko = {
       let style = document.getElementById('koviko');
 
       // Build the CSS
-      let css = `
+      let css = \`
       .nextActionContainer { width: auto!important; padding: 0 4px;  grid-template: "a b . c" / auto auto 1fr auto }
       .nextActionContainer[style~='flex;'] {display: grid!important;}
       .nextActionContainer > div:first-child { width: 70px; }
@@ -434,7 +433,7 @@ const Koviko = {
       ul.koviko .mind{color:#006400}
       ul.koviko .stone{color:#ff0000}
       ul.koviko .heroism{color:#ff0000}
-      `;
+      \`;
       document.getElementById("actionsColumn").style.width="500px";
       document.getElementById("nextActionsListContainer").style.width="380px";
 
@@ -473,20 +472,20 @@ const Koviko = {
       }
 
       //Adds more to the Options panel
-      $('#menu div:nth-child(4) .showthisH').append("<div id='preditorSettings'><br /><b>Predictor Settings</b></div>")
-      $('#preditorSettings').append("<br /><label>Degrees of precision on Time</label><input id='updateTimePrecision' type='number' value='1' min='0' max='10' style='width: 50px;'>");
-      $('#updateTimePrecision').focusout(function() {
-          if($(this).val() > 10) {
-              $(this).val(10);
+      \$('#menu div:nth-child(4) .showthisH').append("<div id='preditorSettings'><br /><b>Predictor Settings</b></div>")
+      \$('#preditorSettings').append("<br /><label>Degrees of precision on Time</label><input id='updateTimePrecision' type='number' value='1' min='0' max='10' style='width: 50px;'>");
+      \$('#updateTimePrecision').focusout(function() {
+          if(\$(this).val() > 10) {
+              \$(this).val(10);
           }
-          if($(this).val() < 1) {
-              $(this).val(1);
+          if(\$(this).val() < 1) {
+              \$(this).val(1);
           }
-          localStorage.setItem('timePrecision', $(this).val());
+          localStorage.setItem('timePrecision', \$(this).val());
       });
-      $('#preditorSettings').append("<br /><label>Width of the Action List</label><input id='actionWidth' type='number' value='500' min='100' max='4000' style='width: 50px; float:right'>");
-      $('#actionWidth').focusout(function() {
-          let tmpVal=$(this).val();
+      \$('#preditorSettings').append("<br /><label>Width of the Action List</label><input id='actionWidth' type='number' value='500' min='100' max='4000' style='width: 50px; float:right'>");
+      \$('#actionWidth').focusout(function() {
+          let tmpVal=\$(this).val();
           localStorage.setItem('actionWidth',tmpVal );       
           document.getElementById("actionsColumn").style.width=tmpVal+"px";
           document.getElementById("nextActionsListContainer").style.width=(tmpVal-120)+"px";
@@ -1185,7 +1184,7 @@ const Koviko = {
        *This is used to see when the loop becomes invalid due to mana cost
        */
       //This is the precision of the Time field
-      let precisionForTime = $('#updateTimePrecision').val();
+      let precisionForTime = \$('#updateTimePrecision').val();
 
       // Initialize all affected resources
       affected.forEach(x => state.resources[x] || (state.resources[x] = 0));
@@ -1211,7 +1210,7 @@ const Koviko = {
           /** @var {number} */
           let currentMana;
 
-          // Make sure that the loop is properly represented in `state.progress`
+          // Make sure that the loop is properly represented in \`state.progress\`
           if (prediction.loop && !(prediction.name in state.progress)) {
             /** @var {Koviko.Predictor~Progression} */
             state.progress[prediction.name] = {
@@ -1340,7 +1339,7 @@ const Koviko = {
             end: Koviko.globals.getLevelFromExp(stats[i].value),
           };
 
-          tooltip += '<tr><td><b>' + _txt(`stats>${i}>short_form`).toUpperCase() + '</b></td><td>' + intToString(level.end, 1) + '</td><td>(+' + intToString(level.end - level.start, 1) + ')</td></tr>';
+          tooltip += '<tr><td><b>' + _txt(\`stats>\${i}>short_form\`).toUpperCase() + '</b></td><td>' + intToString(level.end, 1) + '</td><td>(+' + intToString(level.end - level.start, 1) + ')</td></tr>';
         }
       }
 
@@ -1428,7 +1427,7 @@ const Koviko = {
         if ( resources[name] != 0 ) return ('<li class='+name+'>'+resources[name].toLocaleString('en', {useGrouping:true})+'</li>');
         else return "";
       }).join('');
-      return `<ul class='koviko ${isValid}'>` + Affec + `</ul><div class='koviko showthis'><table>${tooltip || '<b>N/A</b>'}</table></div>`;
+      return \`<ul class='koviko \${isValid}'>\` + Affec + \`</ul><div class='koviko showthis'><table>\${tooltip || '<b>N/A</b>'}</table></div>\`;
     };
 
     /**
@@ -1545,7 +1544,7 @@ const Koviko = {
         try {
           Koviko.globals[varName] = eval(varName);
         } catch (e) {
-          console.error(`Unable to retrieve global '${varName}'.`);
+          console.error(\`Unable to retrieve global '\${varName}'.\`);
           Koviko.hasRan = false;
           return;
         }
@@ -1559,4 +1558,4 @@ const Koviko = {
 // Run the code!
 //window.addEventListener('load', Koviko.run);
 setTimeout(() => document.readyState == 'complete' && Koviko.run(), 2000); // If it hasn't already ran in a couple of seconds, see if it can run
-
+`);

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -216,7 +216,7 @@ const Koviko = {
       const soulstoneBonus = stats[statName].soulstone ? calcSoulstoneMult(stats[statName].soulstone) : 1;
       return soulstoneBonus * (1 + Math.pow(getLevelFromTalent(t[statName]), 0.4) / 3);
     }
-  
+
   },
 
   /** A collection of attributes and a comparison of those attributes from one snapshot to the next. */
@@ -352,7 +352,7 @@ const Koviko = {
       this.initStyle();
       this.initElements()
       this.initPredictions();
-      if(typeof localStorage !== "undefined") { 
+      if(typeof localStorage !== "undefined") {
         if (localStorage.getItem('timePrecision') !== undefined) {
           var loadedVal = localStorage.getItem('timePrecision');
           \$('#updateTimePrecision').val(loadedVal);
@@ -403,9 +403,11 @@ const Koviko = {
       // Build the CSS
       let css = \`
       .nextActionContainer { width: auto!important; padding: 0 4px; display: grid!important; grid-template: "a b . c" / auto auto 1fr auto }
-      .nextActionContainer > div:first-child { width: 50px; }
+      .nextActionContainer > div:first-child { width: 50px; cursor:pointer;}
       .nextActionContainer > div:nth-child(2) { width: 120px; text-align: right; grid-area: c }
       .koviko.valid { grid-area: b; }
+      .nextActionContainer > div:first-child:hover img {filter: invert(.5) sepia(1) saturate(5) hue-rotate(270deg);}
+      .target > div:first-child:hover img {filter: invert(.5) sepia(1) saturate(5) hue-rotate(140deg);}
       #nextActionsList{height:100%!important; overflow-y:scroll;}
       #curActionsListContainer{width:120px!important; z-index: 100;}
       #nextActionsList:hover{margin-left:-40%;padding-left:40%}
@@ -486,7 +488,7 @@ const Koviko = {
       \$('#preditorSettings').append("<br /><label>Width of the Action List</label><input id='actionWidth' type='number' value='500' min='100' max='4000' style='width: 50px; float:right'>");
       \$('#actionWidth').focusout(function() {
           let tmpVal=\$(this).val();
-          localStorage.setItem('actionWidth',tmpVal );       
+          localStorage.setItem('actionWidth',tmpVal );
           document.getElementById("actionsColumn").style.width=tmpVal+"px";
           document.getElementById("nextActionsListContainer").style.width=(tmpVal-120)+"px";
       });
@@ -557,7 +559,19 @@ const Koviko = {
 
         getRewardSS: (dNum) => Math.floor(Math.pow(10, dNum) * Math.pow(1 + getSkillLevel("Divine") / 60, 0.25)),
 
+        setTargetAction: (icon, name) => {
+          if(name === this.target[1]){
+            this.target = ['SS', 'SS'];
+          } else{
+            this.target = [icon, name];
+          }
+          view.updateNextActions();
+        }
+
       });
+
+      // Set default target
+      this.target = ['SS', 'SS'];
 
       // Alias the globals to a shorter variable name
       const g = Koviko.globals;
@@ -585,7 +599,7 @@ const Koviko = {
           let buyMana = Math.min(spendGold * g.Action.BuyManaChallenge.goldCost(), 5000-(r.manaBought||0));
           r.mana+=buyMana;
           r.manaBought= (r.manaBought||0)+buyMana;
-          r.gold-=spendGold; 
+          r.gold-=spendGold;
         }},
         'Meet People': {},
         'Train Strength': {},
@@ -607,7 +621,7 @@ const Koviko = {
         'Start Journey': { effect: (r) => (r.supplies = (r.supplies || 0) - 1, r.town =1), canStart: r => r.supplies >= 1},
         'Open Rift': { effect: (r,k) => (r.supplies = 0, r.town =5, k.dark+=1000)},
 		'Hitch Ride':{ effect: (r,k) => ( r.town =2)},
-	
+
         // Forest Path
         'Explore Forest': {},
         'Wild Mana': { affected: ['mana'], effect: (r) => {
@@ -1057,6 +1071,14 @@ const Koviko = {
       let totalTicks = 0;
 
       /**
+       * Completed actions of the tracked type
+       * @var {number}
+       */
+      let targetActions = 0;
+      
+      const [targetIcon, targetName] = this.target;
+
+      /**
        * All affected resources of the current action list
        * @var {Array.<string>}
        */
@@ -1102,9 +1124,10 @@ const Koviko = {
               total: Koviko.globals.towns[prediction.action.townNum]['total' + prediction.action.varName],
             };
           }
-
+          // Scope the loop variable outside the for loop, so we can read how many actions actually completed
+          let loop = 0;
           // Predict each loop in sequence
-          for (let loop = 0; loop < listedAction.loops; loop++) {
+          for (loop; loop < listedAction.loops; loop++) {
             let canStart = typeof(prediction.canStart) === "function" ? prediction.canStart(state.resources) : prediction.canStart;
             if (!canStart) { isValid = false; }
             if ( !canStart || listedAction.disabled ) { break; }
@@ -1162,10 +1185,17 @@ const Koviko = {
             snapshots[i].snap(state[i]);
           }
 
+          if (listedAction.name === targetName) {
+            targetActions = loop;
+          }
+
           // Update the view
           if (div) {
-            div.className += ' showthat';
+            div.className += ' showthat' + (listedAction.name === targetName ? ' target' : '');
             div.innerHTML += this.template(listedAction.name, affected, state.resources, snapshots, isValid);
+            // Get the icon and listen to clicks on it
+            let setTarget = this.helpers.setTargetAction;
+            div.querySelector(':scope > div').onclick = function(x) {setTarget(this.querySelector('img').outerHTML, listedAction.name)};
           }
         }
       });
@@ -1179,9 +1209,13 @@ const Koviko = {
       while(ms.toString().length < precisionForTime) { ms = "0" + ms; }
 
       let totalTime = ('0' + h).slice(-2) + ":" + ('0' + m).slice(-2) + ":" + ('0' + s).slice(-2) + "." + ms;
-      let dungeonEquilibrium = Math.min(total / 200000,1);
-      let soulStonesPerMinute = dungeonEquilibrium*state.resources.soul / totalTicks * 60;
-      container && (this.totalDisplay.innerHTML = intToString(total) + " | " + totalTime + " | " + soulStonesPerMinute.toFixed(2) + " SS/min");
+
+      if(targetName === 'SS') {
+        // Calculate expected soul stones per run at equilibrium
+        targetActions = Math.min(total / 200000,1) * (state.resources.soul || 0)
+      };
+      
+      container && (this.totalDisplay.innerHTML = intToString(total) + " | " + totalTime + " | " + (targetActions / totalTicks * 60).toFixed(2) + " " + targetIcon + "/min");
 
       // Log useful debugging data
       if (isDebug) {

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -10,8 +10,9 @@
 // @grant        GM_getValue
 // @grant        GM_setValue
 // @run-at       document-idle
+// @inject-into  page
 // ==/UserScript==
-window.eval(`
+
 /** @namespace */
 const Koviko = {
   /**
@@ -33,7 +34,7 @@ const Koviko = {
    * @prop {string} name Name of the action
    * @prop {number} expMult Experience multiplier (typically 1)
    * @prop {number} townNum The town to which the action belongs
-   * @prop {string} varName The unique identifier used for variables in the \`towns\` array
+   * @prop {string} varName The unique identifier used for variables in the `towns` array
    * @prop {number} [segments] Amount of segments per loop
    * @prop {number} [dungeonNum] The dungeon to which the action belongs
    * @prop {Object.<string, number>} stats Stats that affect and are affected by the action
@@ -307,7 +308,7 @@ const Koviko = {
      * Progression
      * @typedef {Object} Koviko.Predictor~Progression
      * @prop {number} completed The amount of total segments completed
-     * @prop {number} progress The amount of progress in segments beyond that already represented in \`completed\`
+     * @prop {number} progress The amount of progress in segments beyond that already represented in `completed`
      * @prop {number} total The amount of successful loops ever completed
      */
 
@@ -355,21 +356,21 @@ const Koviko = {
       if(typeof localStorage !== "undefined") { 
         if (localStorage.getItem('timePrecision') !== undefined) {
           var loadedVal = localStorage.getItem('timePrecision');
-          \$('#updateTimePrecision').val(loadedVal);
+          $('#updateTimePrecision').val(loadedVal);
         }
         if (localStorage.getItem("actionWidth")!=="undefined") {
           let tmpVal=localStorage.getItem("actionWidth");
           document.getElementById("actionsColumn").style.width=tmpVal+"px";
           document.getElementById("nextActionsListContainer").style.width=(tmpVal-120)+"px";
-          \$('#actionWidth').val(tmpVal);
+          $('#actionWidth').val(tmpVal);
         }
       }
-      // Prepare \`updateNextActions\` to be hooked
+      // Prepare `updateNextActions` to be hooked
       if (!view._updateNextActions) {
         view._updateNextActions = view.updateNextActions;
       }
 
-      // Hook \`updateNextActions\` with the predictor's update function
+      // Hook `updateNextActions` with the predictor's update function
       view.updateNextActions = () => {
         view._updateNextActions();
         this.update(actions.next, container);
@@ -401,7 +402,7 @@ const Koviko = {
       let style = document.getElementById('koviko');
 
       // Build the CSS
-      let css = \`
+      let css = `
       .nextActionContainer { width: auto!important; padding: 0 4px;  grid-template: "a b . c" / auto auto 1fr auto }
       .nextActionContainer[style~='flex;'] {display: grid!important;}
       .nextActionContainer > div:first-child { width: 70px; }
@@ -433,7 +434,7 @@ const Koviko = {
       ul.koviko .mind{color:#006400}
       ul.koviko .stone{color:#ff0000}
       ul.koviko .heroism{color:#ff0000}
-      \`;
+      `;
       document.getElementById("actionsColumn").style.width="500px";
       document.getElementById("nextActionsListContainer").style.width="380px";
 
@@ -472,20 +473,20 @@ const Koviko = {
       }
 
       //Adds more to the Options panel
-      \$('#menu div:nth-child(4) .showthisH').append("<div id='preditorSettings'><br /><b>Predictor Settings</b></div>")
-      \$('#preditorSettings').append("<br /><label>Degrees of precision on Time</label><input id='updateTimePrecision' type='number' value='1' min='0' max='10' style='width: 50px;'>");
-      \$('#updateTimePrecision').focusout(function() {
-          if(\$(this).val() > 10) {
-              \$(this).val(10);
+      $('#menu div:nth-child(4) .showthisH').append("<div id='preditorSettings'><br /><b>Predictor Settings</b></div>")
+      $('#preditorSettings').append("<br /><label>Degrees of precision on Time</label><input id='updateTimePrecision' type='number' value='1' min='0' max='10' style='width: 50px;'>");
+      $('#updateTimePrecision').focusout(function() {
+          if($(this).val() > 10) {
+              $(this).val(10);
           }
-          if(\$(this).val() < 1) {
-              \$(this).val(1);
+          if($(this).val() < 1) {
+              $(this).val(1);
           }
-          localStorage.setItem('timePrecision', \$(this).val());
+          localStorage.setItem('timePrecision', $(this).val());
       });
-      \$('#preditorSettings').append("<br /><label>Width of the Action List</label><input id='actionWidth' type='number' value='500' min='100' max='4000' style='width: 50px; float:right'>");
-      \$('#actionWidth').focusout(function() {
-          let tmpVal=\$(this).val();
+      $('#preditorSettings').append("<br /><label>Width of the Action List</label><input id='actionWidth' type='number' value='500' min='100' max='4000' style='width: 50px; float:right'>");
+      $('#actionWidth').focusout(function() {
+          let tmpVal=$(this).val();
           localStorage.setItem('actionWidth',tmpVal );       
           document.getElementById("actionsColumn").style.width=tmpVal+"px";
           document.getElementById("nextActionsListContainer").style.width=(tmpVal-120)+"px";
@@ -1184,7 +1185,7 @@ const Koviko = {
        *This is used to see when the loop becomes invalid due to mana cost
        */
       //This is the precision of the Time field
-      let precisionForTime = \$('#updateTimePrecision').val();
+      let precisionForTime = $('#updateTimePrecision').val();
 
       // Initialize all affected resources
       affected.forEach(x => state.resources[x] || (state.resources[x] = 0));
@@ -1210,7 +1211,7 @@ const Koviko = {
           /** @var {number} */
           let currentMana;
 
-          // Make sure that the loop is properly represented in \`state.progress\`
+          // Make sure that the loop is properly represented in `state.progress`
           if (prediction.loop && !(prediction.name in state.progress)) {
             /** @var {Koviko.Predictor~Progression} */
             state.progress[prediction.name] = {
@@ -1339,7 +1340,7 @@ const Koviko = {
             end: Koviko.globals.getLevelFromExp(stats[i].value),
           };
 
-          tooltip += '<tr><td><b>' + _txt(\`stats>\${i}>short_form\`).toUpperCase() + '</b></td><td>' + intToString(level.end, 1) + '</td><td>(+' + intToString(level.end - level.start, 1) + ')</td></tr>';
+          tooltip += '<tr><td><b>' + _txt(`stats>${i}>short_form`).toUpperCase() + '</b></td><td>' + intToString(level.end, 1) + '</td><td>(+' + intToString(level.end - level.start, 1) + ')</td></tr>';
         }
       }
 
@@ -1427,7 +1428,7 @@ const Koviko = {
         if ( resources[name] != 0 ) return ('<li class='+name+'>'+resources[name].toLocaleString('en', {useGrouping:true})+'</li>');
         else return "";
       }).join('');
-      return \`<ul class='koviko \${isValid}'>\` + Affec + \`</ul><div class='koviko showthis'><table>\${tooltip || '<b>N/A</b>'}</table></div>\`;
+      return `<ul class='koviko ${isValid}'>` + Affec + `</ul><div class='koviko showthis'><table>${tooltip || '<b>N/A</b>'}</table></div>`;
     };
 
     /**
@@ -1544,7 +1545,7 @@ const Koviko = {
         try {
           Koviko.globals[varName] = eval(varName);
         } catch (e) {
-          console.error(\`Unable to retrieve global '\${varName}'.\`);
+          console.error(`Unable to retrieve global '${varName}'.`);
           Koviko.hasRan = false;
           return;
         }
@@ -1558,4 +1559,4 @@ const Koviko = {
 // Run the code!
 //window.addEventListener('load', Koviko.run);
 setTimeout(() => document.readyState == 'complete' && Koviko.run(), 2000); // If it hasn't already ran in a couple of seconds, see if it can run
-`);
+

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -798,7 +798,7 @@ const Koviko = {
         'Mana Well': {
           effect: (r,k)=> {
             r.wellLoot = (r.wellLoot || 0) + 1;
-            r.mana += r.wellLoot <= towns[1].goodWells ? Math.max(5000 - Math.floor(r.totalTicks/5),0) : 0;
+            r.mana += r.wellLoot <= towns[5].goodWells ? Math.max(5000 - Math.floor(r.totalTicks/5),0) : 0;
           }
 
         },

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1040,6 +1040,16 @@ const Koviko = {
           effect: { loop: (r) => (r.heroism=(r.heroism||0)+1) }
         }},
 
+        'Dead Trial': { affected: ['zombie'], loop: {
+          max: (a) => trialFloors[a.trialNum],
+          cost: (p, a) => segment => precision3(Math.pow(a.floorScaling, Math.floor((p.completed + segment) / a.segments + .0000001)) * a.baseScaling),
+          tick: (p, a, s, k, r) => offset => {
+            const floor = Math.floor(p.completed / a.segments + .0000001);
+            return floor in trials[a.trialNum] ? (g.getSkillLevelFromExp(k.dark) * r.zombie / 2) * h.getStatProgress(p, a, s, offset) * Math.sqrt(1 + trials[a.trialNum][floor].completed / 200) : 0;
+          },
+          effect: { loop: (r) => (r.zombie++) }
+        }},
+
         'Dark Ritual': { affected: ['ritual'], canStart: (input) => (input.rep <= -5), loop: {
           max: () => 1,
           cost: (p) => segment => 1000000 * (segment * 2 + 1),

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -866,7 +866,7 @@ const Koviko = {
           canStart: (input)=>(input.lpotions>0),
           effect: (r,k)=>(r.lpotions--,k.wunderkind+=100),
         },
-        'Escape': { effect: (r) => (r.town=7)},
+        'Escape': {canStart: (input) => (input.totalTicks<=50*60), effect: (r) => (r.town=7)},
         'Open Portal': { effect: (r,k) => (r.town=1,k.restoration+=2500)},
 
         // Commerceville
@@ -1142,11 +1142,6 @@ const Koviko = {
             // Only for Adventure Guild
             if ( listedAction.name == "Adventure Guild" ) {
               state.resources.mana += state.resources.adventures * 200;
-            }
-
-            //Only for Escape (Jungle Path) - only works in the first 60s (=50*60 ticks)
-            if ((listedAction.name=='Escape') && (totalTicks>=(50*60))) {
-              isValid=false;
             }
 
             // Run the effect, now that the mana checks are complete

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -402,7 +402,8 @@ const Koviko = {
 
       // Build the CSS
       let css = \`
-      .nextActionContainer { width: auto!important; padding: 0 4px; display: grid!important; grid-template: "a b . c" / auto auto 1fr auto }
+      .nextActionContainer { width: auto!important; padding: 0 4px;  grid-template: "a b . c" / auto auto 1fr auto }
+      .nextActionContainer[style~='flex;'] {display: grid!important;}
       .nextActionContainer > div:first-child { width: 70px; }
       .nextActionContainer > div:nth-child(2) { width: 120px; text-align: right; grid-area: c }
       .koviko.valid { grid-area: b; }

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -701,8 +701,10 @@ const Koviko = {
         'Accept Donations': { affected: ['gold', 'rep'], canStart: (input) => {
           return (input.rep >= 0);
         }, effect: (r) => {
-          // TODO: Proper lootable first system
-          r.gold += 20;
+          r.donateLoot = (r.donateLoot || 0) + 1;
+          if (r.donateLoot<=towns[4].goodDonations) {
+            r.gold += 20;
+          }
           r.rep -= 1;
         }},
         'Tidy Up': { affected: ['gold', 'rep'], loop: {

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.8.4
+// @version      1.8.5
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/
@@ -403,7 +403,7 @@ const Koviko = {
       // Build the CSS
       let css = \`
       .nextActionContainer { width: auto!important; padding: 0 4px; display: grid!important; grid-template: "a b . c" / auto auto 1fr auto }
-      .nextActionContainer > div:first-child { width: 50px; }
+      .nextActionContainer > div:first-child { width: 70px; }
       .nextActionContainer > div:nth-child(2) { width: 120px; text-align: right; grid-area: c }
       .koviko.valid { grid-area: b; }
       #nextActionsList{height:100%!important; overflow-y:scroll;}

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.8.8
+// @version      1.8.9
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/
@@ -1255,7 +1255,7 @@ const Koviko = {
       while(ms.toString().length < precisionForTime) { ms = "0" + ms; }
 
       let totalTime = ('0' + h).slice(-2) + ":" + ('0' + m).slice(-2) + ":" + ('0' + s).slice(-2) + "." + ms;
-      let dungeonEquilibrium = Math.min(total / 200000,1);
+      let dungeonEquilibrium = Math.min(Math.sqrt(total / 200000),1);
       let soulStonesPerMinute = dungeonEquilibrium*state.resources.soul / totalTicks * 60;
       container && (this.totalDisplay.innerHTML = intToString(total) + " | " + totalTime + " | " + soulStonesPerMinute.toFixed(2) + " SS/min");
 

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -808,7 +808,10 @@ const Koviko = {
 
         },
         'Destroy Pylons': { affected: ['pylons'], effect: (r) => {
-          r.pylons += 1;
+          r.pylonLoot = (r.pylonLoot || 0) + 1;
+          if (r.pylonLoot<=towns[5].goodPylons) {
+            r.pylons += 1;
+          }
         }},
         'Raise Zombie': { affected: ['blood', 'zombie'],
           canStart: (input) => (input.blood >= 1),

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -431,6 +431,7 @@ const Koviko = {
       ul.koviko .artifacts{color:#ffd700}
       ul.koviko .mind{color:#006400}
       ul.koviko .stone{color:#ff0000}
+      ul.koviko .heroism{color:#ff0000}
       \`;
       document.getElementById("actionsColumn").style.width="500px";
       document.getElementById("nextActionsListContainer").style.width="380px";
@@ -1024,11 +1025,21 @@ const Koviko = {
           cost: (p, a) => segment => g.precision3(Math.pow(3, Math.floor((p.completed + segment) / a.segments + .0000001)) * 5e5),
           tick: (p, a, s, k, r) => offset => {
             let floor = Math.floor(p.completed / a.segments + .0000001);
-
             return floor in g.dungeons[a.dungeonNum] ? (h.getTeamCombat(r, k) + g.getSkillLevelFromExp(k.magic)) * h.getStatProgress(p, a, s, offset) * Math.sqrt(1 + g.dungeons[a.dungeonNum][floor].completed / 200) : 0;
           },
           effect: { end: (r, k) => (k.combat += 15, k.magic += 15), loop: (r) => r.soul +=h.getRewardSS(1)  }
         }},
+
+        'Heroes Trial': { affected: ['heroism'], loop: {
+          max: (a) => trialFloors[a.trialNum],
+          cost: (p, a) => segment => precision3(Math.pow(a.floorScaling, Math.floor((p.completed + segment) / a.segments + .0000001)) * a.baseScaling),
+          tick: (p, a, s, k, r) => offset => {
+            const floor = Math.floor(p.completed / a.segments + .0000001);
+            return floor in trials[a.trialNum] ? h.getTeamCombat(r, k) * h.getStatProgress(p, a, s, offset) * Math.sqrt(1 + trials[a.trialNum][floor].completed / 200) : 0;
+          },
+          effect: { loop: (r) => (r.heroism=(r.heroism||0)+1) }
+        }},
+
         'Dark Ritual': { affected: ['ritual'], canStart: (input) => (input.rep <= -5), loop: {
           max: () => 1,
           cost: (p) => segment => 1000000 * (segment * 2 + 1),

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -431,8 +431,6 @@ const Koviko = {
       ul.koviko .artifacts{color:#ffd700}
       ul.koviko .mind{color:#006400}
       ul.koviko .stone{color:#ff0000}
-      .actionOptions .showthis {width:max-content;bottom:100%;max-width:400px;margin-bottom:5px;}
-      .travelContainer, .actionContainer {position:relative;}
       \`;
       document.getElementById("actionsColumn").style.width="500px";
       document.getElementById("nextActionsListContainer").style.width="380px";

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -412,7 +412,7 @@ const Koviko = {
       #nextActionsList:hover{margin-left:-40%;padding-left:40%}
       #actionList>div:nth-child(2){left: 53px !important}
       .nextActionContainer:nth-child(1n+9) .showthis {bottom: 5px; top: unset;}
-      span.koviko{font-weight:bold;color:#8293ff}
+      span.koviko{font-weight:bold;color:#8293ff;padding-left:50px;}
       div.koviko{top:-5px;left:auto;right:100%}
       ul.koviko{list-style:none;margin:0;padding:0;pointer-events:none;display:inline;}
       ul.koviko li{display:inline-block;margin: 0 2px;font-weight:bold;font-size:90%}
@@ -468,7 +468,6 @@ const Koviko = {
       if (!this.totalDisplay) {
         this.totalDisplay = document.createElement('span');
         this.totalDisplay.className = 'koviko';
-        this.totalDisplay.style = 'padding-left:50px;'
         parent.appendChild(this.totalDisplay);
       }
 
@@ -1295,6 +1294,13 @@ const Koviko = {
       let dungeonEquilibrium = Math.min(Math.sqrt(total / 200000),1);
       let soulStonesPerMinute = dungeonEquilibrium*state.resources.soul / totalTicks * 60;
       container && (this.totalDisplay.innerHTML = intToString(total) + " | " + totalTime + " | " + soulStonesPerMinute.toFixed(2) + " SS/min");
+
+      if (this.resourcePerMinute>soulStonesPerMinute) {
+        this.totalDisplay.style='color: #FF0000';
+      } else {
+        this.totalDisplay.style='color: 8293ff'
+      }
+     this.resourcePerMinute=soulStonesPerMinute;
 
       // Log useful debugging data
       if (isDebug) {

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.9.0
+// @version      1.9.1
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/
@@ -584,7 +584,7 @@ const Koviko = {
         'Buy Glasses': { affected: ['gold', 'glassess'], effect: (r) => (r.gold -= 10, r.glasses = true) },
         'Buy Mana Z1': { affected: ['mana', 'gold'], effect: (r) => (r.mana += r.gold * g.Action.BuyManaZ1.goldCost(), r.gold = 0) },
         'Buy Mana Challenge': { affected: ['mana', 'gold'], canStart: (input) => ((input.manaBought||0)<totalMerchantMana), effect: (r) => {
-          let spendGold = Math.min(r.gold, 200);
+          let spendGold = Math.min(r.gold, 300);
           let buyMana = Math.min(spendGold * g.Action.BuyManaChallenge.goldCost(), totalMerchantMana-(r.manaBought||0));
           r.mana+=buyMana;
           r.manaBought= (r.manaBought||0)+buyMana;

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -885,7 +885,7 @@ const Koviko = {
         'Pick Pockets': { canStart: (input) => (input.thieves > 0), cost: (p, a) => {
           return Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thievery) / 60, 0.25));
         }, effect: (r, k) => {
-          r.gold += Math.floor(Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thievery) / 60, 0.25)) * g.getGuildRankBonus(r.thievery));
+          r.gold += Math.floor(Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(r.thievery) / 60, 0.25)) * g.getGuildRankBonus(r.thievery));
         }},
         'Invest': {affected:['gold'],canStart: (input)=>(input.gold>0),effect: (r,k)=> {
            k.mercantilism+=100;

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.8.6
+// @version      1.8.7
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/
@@ -879,18 +879,18 @@ const Koviko = {
           return input.rep < 0;
         }, loop: {
           cost: (p) => segment => g.precision3(Math.pow(1.3, p.completed + segment)) * 5e8,
-          tick: (p, a, s, k, r) => offset => (g.getSkillLevelFromExp(k.practical) + g.getSkillLevelFromExp(k.thievery)) * (1 + g.getLevelFromExp(s[a.loopStats[(p.completed + offset) % a.loopStats.length]]) / 100) * Math.sqrt(1 + p.total / 1000),
+          tick: (p, a, s, k, r) => offset => (g.getSkillLevelFromExp(k.practical) + g.getSkillLevelFromExp(k.thieves)) * (1 + g.getLevelFromExp(s[a.loopStats[(p.completed + offset) % a.loopStats.length]]) / 100) * Math.sqrt(1 + p.total / 1000),
           effect: { segment: (r) => (r.gold += 10, r.thieves++) }
         }},
         'Pick Pockets': { canStart: (input) => (input.thieves > 0), cost: (p, a) => {
-          return Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thievery) / 60, 0.25));
+          return Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thieves) / 60, 0.25));
         }, effect: (r, k) => {
-          r.gold += Math.floor(Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(r.thievery) / 60, 0.25)) * h.getGuildRankBonus(r.thievery));
+          r.gold += Math.floor(Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(r.thieves) / 60, 0.25)) * h.getGuildRankBonus(r.thieves));
         }},
         'Rob Warehouse': { canStart: (input) => (input.thieves > 0), cost: (p, a) => {
-          return Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thievery) / 60, 0.25));
+          return Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thieves) / 60, 0.25));
         }, effect: (r, k) => {
-          r.gold += Math.floor(Math.floor(10 * Math.pow(1 + g.getSkillLevelFromExp(r.thievery) / 60, 0.25)) * h.getGuildRankBonus(r.thievery));
+          r.gold += Math.floor(Math.floor(10 * Math.pow(1 + g.getSkillLevelFromExp(r.thieves) / 60, 0.25)) * h.getGuildRankBonus(r.thieves));
         }},
         'Invest': {affected:['gold'],canStart: (input)=>(input.gold>0),effect: (r,k)=> {
            k.mercantilism+=100;

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.8.5
+// @version      1.8.6
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/
@@ -886,6 +886,11 @@ const Koviko = {
           return Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thievery) / 60, 0.25));
         }, effect: (r, k) => {
           r.gold += Math.floor(Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(r.thievery) / 60, 0.25)) * h.getGuildRankBonus(r.thievery));
+        }},
+        'Rob Warehouse': { canStart: (input) => (input.thieves > 0), cost: (p, a) => {
+          return Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thievery) / 60, 0.25));
+        }, effect: (r, k) => {
+          r.gold += Math.floor(Math.floor(10 * Math.pow(1 + g.getSkillLevelFromExp(r.thievery) / 60, 0.25)) * h.getGuildRankBonus(r.thievery));
         }},
         'Invest': {affected:['gold'],canStart: (input)=>(input.gold>0),effect: (r,k)=> {
            k.mercantilism+=100;

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.8.7
+// @version      1.8.8
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -430,6 +430,7 @@ const Koviko = {
       ul.koviko .ritual{color:#ff1493}
       ul.koviko .artifacts{color:#ffd700}
       ul.koviko .mind{color:#006400}
+      ul.koviko .stone{color:#ff0000}
       .actionOptions .showthis {width:max-content;bottom:100%;max-width:400px;margin-bottom:5px;}
       .travelContainer, .actionContainer {position:relative;}
       \`;
@@ -906,7 +907,71 @@ const Koviko = {
         }},
 
         //Valley of the Gods
-         
+
+        //Tower Actions (ALL ZONES)
+        'RuinsZ1': {},
+        'RuinsZ3': {},
+        'RuinsZ5': {},
+        'RuinsZ6': {},
+
+        'HaulZ1': {affected: ['stone'],canStart: (input)=>((input.stone||0)<1 && stonesUsed[1] < 250), effect: (r) => {
+          let t=towns[1]; //Area of the Action
+          if (t.goodStonesZ1>0) {
+            r.stone=1;
+            return;
+          }
+          if (t.totalStonesZ1<=(t.checkedStonesZ1+(r.stoneCheckedZ1||0))) {
+            return; //No more stones to check..
+          }
+          r.stoneCheckedZ1=(r.stoneCheckedZ1||0)+1;
+          if (((t.checkedStonesZ1+r.stoneCheckedZ1)%1000)==0) {
+            r.stone=1;
+          } 
+        }},
+        'HaulZ3': {affected: ['stone'],canStart: (input)=>((input.stone||0)<1 && stonesUsed[3] < 250), effect: (r) => {
+          let t=towns[3]; //Area of the Action
+          if (t.goodStonesZ3>0) {
+            r.stone=1;
+            return;
+          }
+          if (t.totalStonesZ3<=(t.checkedStonesZ3+(r.stoneCheckedZ3||0))) {
+            return; //No more stones to check..
+          }
+          r.stoneCheckedZ3=(r.stoneCheckedZ3||0)+1;
+          if (((t.checkedStonesZ3+r.stoneCheckedZ3)%1000)==0) {
+            r.stone=1;
+          } 
+        }},
+        'HaulZ5': {affected: ['stone'],canStart: (input)=>((input.stone||0)<1 && stonesUsed[5] < 250), effect: (r) => {
+          let t=towns[5]; //Area of the Action
+          if (t.goodStonesZ5>0) {
+            r.stone=1;
+            return;
+          }
+          if (t.totalStonesZ5<=(t.checkedStonesZ5+(r.stoneCheckedZ5||0))) {
+            return; //No more stones to check..
+          }
+          r.stoneCheckedZ5=(r.stoneCheckedZ5||0)+1;
+          if (((t.checkedStonesZ5+r.stoneCheckedZ5)%1000)==0) {
+            r.stone=1;
+          } 
+        }},
+        'HaulZ6': {affected: ['stone'],canStart: (input)=>((input.stone||0)<1 && stonesUsed[6] < 250), effect: (r) => {
+          let t=towns[6]; //Area of the Action
+          if (t.goodStonesZ6>0) {
+            r.stone=1;
+            return;
+          }
+          if (t.totalStonesZ6<=(t.checkedStonesZ3+(r.stoneCheckedZ6||0))) {
+            return; //No more stones to check..
+          }
+          r.stoneCheckedZ6=(r.stoneCheckedZ6||0)+1;
+          if (((t.checkedStonesZ6+r.stoneCheckedZ6)%1000)==0) {
+            r.stone=1;
+          } 
+        }},
+
+        'Build Tower': {affected: ['stone'],canStart: (input)=>((input.stone||0)==1)},
 
         // Loops without Max
         'Heal The Sick': { affected: ['rep'], canStart: (input) => (input.rep >= 1), loop: {
@@ -977,6 +1042,16 @@ const Koviko = {
           effect: { loop: (r) => r.mind++ },
         }},
         'Imbue Body': { affected: ['body'], loop: {
+          max: () => 1,
+          cost: (p) => segment => 100000000 * (segment * 5 + 1),
+          tick: (p, a, s, k) => offset => {
+            let attempt = Math.floor(p.completed / a.segments + .0000001);
+
+            return attempt < 1 ? (g.getSkillLevelFromExp(k.magic) * h.getStatProgress(p, a, s, offset)) : 0;
+          },
+          effect: { loop: (r) => r.body++ },
+        }},
+        'Imbue Soul': { affected: ['body'], loop: {
           max: () => 1,
           cost: (p) => segment => 100000000 * (segment * 5 + 1),
           tick: (p, a, s, k) => offset => {

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -583,9 +583,9 @@ const Koviko = {
         }},
         'Buy Glasses': { affected: ['gold', 'glassess'], effect: (r) => (r.gold -= 10, r.glasses = true) },
         'Buy Mana Z1': { affected: ['mana', 'gold'], effect: (r) => (r.mana += r.gold * g.Action.BuyManaZ1.goldCost(), r.gold = 0) },
-        'Buy Mana Challenge': { affected: ['mana', 'gold'], canStart: (input) => ((input.manaBought||0)<5000), effect: (r) => {
+        'Buy Mana Challenge': { affected: ['mana', 'gold'], canStart: (input) => ((input.manaBought||0)<totalMerchantMana), effect: (r) => {
           let spendGold = Math.min(r.gold, 200);
-          let buyMana = Math.min(spendGold * g.Action.BuyManaChallenge.goldCost(), 5000-(r.manaBought||0));
+          let buyMana = Math.min(spendGold * g.Action.BuyManaChallenge.goldCost(), totalMerchantMana-(r.manaBought||0));
           r.mana+=buyMana;
           r.manaBought= (r.manaBought||0)+buyMana;
           r.gold-=spendGold; 

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -870,10 +870,10 @@ const Koviko = {
         'Open Portal': { effect: (r,k) => (r.town=1,k.restoration+=2500)},
 
         // Commerceville
-        'Excursion': { affected: ['gold'], cost: (p, a) => {
-          return (p.thieves >= 0 ? 2 : 10);
+        'Excursion': { affected: ['gold'], canStart: (input) => {
+          return (input.thieves >= 0 ? 2 : 10);
         }, effect: (r, k) => {
-          r.gold -= (p.thieves >= 0 ? 2 : 10);
+          r.gold -= (r.thieves >= 0 ? 2 : 10);
         }},
         'Thieves Guild': { affected: ['gold', 'thieves'], canStart: (input) => {
           return input.rep < 0;

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -991,6 +991,7 @@ const Koviko = {
         'SurveyZ5': {},
         'SurveyZ6': {},
         'SurveyZ7': {},
+        'SurveyZ8': {},
 
       };
 

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -885,7 +885,7 @@ const Koviko = {
         'Pick Pockets': { canStart: (input) => (input.thieves > 0), cost: (p, a) => {
           return Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thievery) / 60, 0.25));
         }, effect: (r, k) => {
-          r.gold += Math.floor(Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(r.thievery) / 60, 0.25)) * g.getGuildRankBonus(r.thievery));
+          r.gold += Math.floor(Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(r.thievery) / 60, 0.25)) * h.getGuildRankBonus(r.thievery));
         }},
         'Invest': {affected:['gold'],canStart: (input)=>(input.gold>0),effect: (r,k)=> {
            k.mercantilism+=100;

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.8.3
+// @version      1.8.4
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -850,11 +850,11 @@ const Koviko = {
 
         // Jungle Path
         'Explore Jungle': { affected: ['herbs'],effect: (r) => (r.herbs++) },
-        'Fight Jungle Monsters': { affected: ['hide'], loop: {
+        'Fight Jungle Monsters': { affected: ['blood'], loop: {
           cost: (p, a) => segment => g.precision3(Math.pow(1.3, p.completed + segment)) * 1e8,
           tick: (p, a, s, k, r) => offset => h.getSelfCombat(r, k) * h.getStatProgress(p, a, s, offset) *
                                              Math.sqrt(1 + p.total / 1000),
-          effect: { segment: (r) => r.hide += 1 },
+          effect: { segment: (r) => r.blood=(r.blood||0)+1 },
         }},
         'Rescue Survivors': {
           loop: {
@@ -862,11 +862,11 @@ const Koviko = {
             tick: (p, a, s, k) => offset => g.getSkillLevelFromExp(k.magic) * Math.max(g.getSkillLevelFromExp(k.restoration) / 100, 1) * h.getStatProgress(p, a, s, offset) * Math.sqrt(1 + p.total / 100),
             effect: { loop: (r) => (r.survivor= (r.survivor||0)+1,r.rep+=4) },
         }},
-        'Prepare Buffet': { affected:['herbs','hide'],
-          canStart: (input) => ((input.herbs>=10) && (input.hide>=1)),
+        'Prepare Buffet': { affected:['herbs','blood'],
+          canStart: (input) => ((input.herbs>=10) && (input.blood>=1)),
           effect: (r,k) => {
             r.herbs-=10;
-            r.hide--;
+            r.blood--;
             k.gluttony+=5*r.survivor;
           }
         },

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1046,7 +1046,7 @@ const Koviko = {
           cost: (p, a) => segment => precision3(Math.pow(a.floorScaling, Math.floor((p.completed + segment) / a.segments + .0000001)) * a.baseScaling),
           tick: (p, a, s, k, r) => offset => {
             const floor = Math.floor(p.completed / a.segments + .0000001);
-            return floor in trials[a.trialNum] ? (g.getSkillLevelFromExp(k.dark) * r.zombie / 2) * h.getStatProgress(p, a, s, offset) * Math.sqrt(1 + trials[a.trialNum][floor].completed / 200) : 0;
+            return floor in trials[a.trialNum] ? h.getZombieStrength(r, k) * h.getStatProgress(p, a, s, offset) * Math.sqrt(1 + trials[a.trialNum][floor].completed / 200) : 0;
           },
           effect: { loop: (r) => (r.zombie++) }
         }},

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.9.2
+// @version      1.9.3
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         IdleLoops Predictor Makro
 // @namespace    https://github.com/MakroCZ/
-// @version      1.9.1
+// @version      1.9.2
 // @description  Predicts the amount of resources spent and gained by each action in the action list. Valid as of IdleLoops v.85/Omsi6.
 // @author       Koviko <koviko.net@gmail.com>
 // @match        https://omsi6.github.io/loops/
@@ -509,7 +509,7 @@ const Koviko = {
          * @return {number} Current level of town attribute
          * @memberof Koviko.Predictor#helpers
          */
-        getTownLevelFromExp: (exp) => Math.floor((Math.sqrt(8 * exp / 100 + 1) - 1) / 2),
+        getTownLevelFromExp: (exp) => Math.min(Math.floor((Math.sqrt(8 * exp / 100 + 1) - 1) / 2),100),
 
         /**
          * Get the current guild rank's bonus, noting that there is a max of 15 ranks, base zero.
@@ -652,9 +652,9 @@ const Koviko = {
         'Read Books': {},
         'Gather Team': { affected: ['gold'], effect: (r) => (r.team = (r.team || 0) + 1, r.gold -= r.team * 100) },
         'Craft Armor': { affected: ['hide'], canStart: (input) => (input.hide >= 2), effect: (r) => (r.hide -= 2, r.armor = (r.armor || 0) + 1) },
-        'Apprentice': { effect: (r, k) => (r.apprentice = (r.apprentice || 0) + 30 * h.getGuildRankBonus(r.crafts || 0), k.crafting += 10 * (1 + h.getTownLevelFromExp(r.apprentice) / 100)) },
-        'Mason': { effect: (r, k) => (r.mason = (r.mason || 0) + 20 * h.getGuildRankBonus(r.crafts || 0), k.crafting += 20 * (1 + h.getTownLevelFromExp(r.mason) / 100)) },
-        'Architect': { effect: (r, k) => (r.architect = (r.architect || 0) + 10 * h.getGuildRankBonus(r.crafts || 0), k.crafting += 40 * (1 + h.getTownLevelFromExp(r.architect) / 100)) },
+        'Apprentice': { effect: (r, k) => Math.min((r.apprentice = (r.apprentice || towns[2].expApprentice) + 30 * h.getGuildRankBonus(r.crafts || 0),505000), k.crafting += 10 * (1 + h.getTownLevelFromExp(r.apprentice) / 100)) },
+        'Mason': { effect: (r, k) => (r.mason = Math.min((r.mason || towns[2].expMason) + 20 * h.getGuildRankBonus(r.crafts || 0),505000), k.crafting += 20 * (1 + h.getTownLevelFromExp(r.mason) / 100)) },
+        'Architect': { effect: (r, k) => Math.min((r.architect = (r.architect || towns[2].expArchitect) + 10 * h.getGuildRankBonus(r.crafts || 0),505000), k.crafting += 40 * (1 + h.getTownLevelFromExp(r.architect) / 100)) },
         'Buy Pickaxe': { affected: ['gold'], effect: (r) => (r.gold -= 200, r.pickaxe = true) },
         'Start Trek': { effect: (r) => r.town = 3 },
         'Underworld': {affected: ['gold'], effect: (r) => (r.town = 7,r.gold-=500),canStart:(input)=>(input.gold>=500) },

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -897,6 +897,10 @@ const Koviko = {
            k.mercantilism+=100;
            r.gold=0;
         }},
+        'Seminar': {affected:['gold'],canStart: (input)=>(input.gold>=1000),effect: (r,k)=> {
+           k.leadership+=200;
+           r.gold-=1000;
+        }},
         'Collect Interest': {affected:['gold'],effect: (r,k)=> {
            k.mercantilism+=50;
            r.gold+=Math.floor(goldInvested * .001);

--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -882,14 +882,10 @@ const Koviko = {
           tick: (p, a, s, k, r) => offset => (g.getSkillLevelFromExp(k.practical) + g.getSkillLevelFromExp(k.thieves)) * (1 + g.getLevelFromExp(s[a.loopStats[(p.completed + offset) % a.loopStats.length]]) / 100) * Math.sqrt(1 + p.total / 1000),
           effect: { segment: (r) => (r.gold += 10, r.thieves++) }
         }},
-        'Pick Pockets': { canStart: (input) => (input.thieves > 0), cost: (p, a) => {
-          return Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thieves) / 60, 0.25));
-        }, effect: (r, k) => {
+        'Pick Pockets': { canStart: (input) => (input.thieves > 0), effect: (r, k) => {
           r.gold += Math.floor(Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(r.thieves) / 60, 0.25)) * h.getGuildRankBonus(r.thieves));
         }},
-        'Rob Warehouse': { canStart: (input) => (input.thieves > 0), cost: (p, a) => {
-          return Math.floor(1 * Math.pow(1 + g.getSkillLevelFromExp(p.thieves) / 60, 0.25));
-        }, effect: (r, k) => {
+        'Rob Warehouse': { canStart: (input) => (input.thieves > 0), effect: (r, k) => {
           r.gold += Math.floor(Math.floor(10 * Math.pow(1 + g.getSkillLevelFromExp(r.thieves) / 60, 0.25)) * h.getGuildRankBonus(r.thieves));
         }},
         'Invest': {affected:['gold'],canStart: (input)=>(input.gold>0),effect: (r,k)=> {


### PR DESCRIPTION
Lets the user click on an icon in the next actions list to have the predictor target it and show how many are completed per minute.

Defaults to soulstones, and targetting the current target resets to soulstones.

Turns the icons green on hover (red if it's the targetted action).

Urgh vscode didn't show the whitespace changes. Programming on windows woo.